### PR TITLE
feat(auth): add forgot password form

### DIFF
--- a/src/app/auth/forgot-password/forgot-password-form.tsx
+++ b/src/app/auth/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import ResetPasswordSchema from '@/app/auth/forgot-password/forgot-password-schema'
+import { zodResolver } from '@hookform/resolvers/zod'
+import AuthCard from '@/app/auth/components/auth-card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const ForgotPasswordForm = () => {
+  const form = useForm<z.infer<typeof ResetPasswordSchema>>({
+    resolver: zodResolver(ResetPasswordSchema),
+    defaultValues: {
+      email: '',
+    },
+  })
+
+  return (
+    <Form {...form}>
+      <form>
+        <AuthCard title={'Forgot Password'} subtitle={'Reset your password.'}>
+          <FormField
+            name={'email'}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder={'Email'}
+                    type={'text'}
+                    aria-label={'email'}
+                    // disabled={isPending}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type={'submit'}
+            className={'mt-12 w-full'}
+            // isLoading={isPending}
+          >
+            Reset
+          </Button>
+        </AuthCard>
+      </form>
+    </Form>
+  )
+}
+
+export default ForgotPasswordForm

--- a/src/app/auth/forgot-password/forgot-password-schema.ts
+++ b/src/app/auth/forgot-password/forgot-password-schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email(),
+})
+export default forgotPasswordSchema

--- a/src/stories/AuthCard.stories.tsx
+++ b/src/stories/AuthCard.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import LoginForm from '@/app/auth/login/login-form'
+import ForgotPasswordForm from '@/app/auth/forgot-password/forgot-password-form'
 
 const meta: Meta = {
   title: 'Organisms/AuthCard',
@@ -13,4 +14,8 @@ type Story = StoryObj<typeof meta>
 
 export const Login: Story = {
   render: () => <LoginForm />,
+}
+
+export const ForgotPassword: Story = {
+  render: () => <ForgotPasswordForm />,
 }


### PR DESCRIPTION
### TL;DR

This pull request introduces a new forgot password form.

### What changed?

Two new files `forgot-password-form.tsx` and `forgot-password-schema.ts` have been created in the auth directory.

The `forgot-password-form.tsx` contains a new form for users to input their email and request a password reset. The form uses react-hook-form for form management and zod for form validation, in-line with the current tech stack choices. The file `forgot-password-schema.ts` contains the schema to validate the email field in the forgot password form.

Also, Storybook has been updated with the new forgot password form.

### How to test?

You can test this by running the app. Navigate to the forgot password form, try submitting with an invalid email and you'll see a validation error.

Also, you can check the implementation in StoryBook .

### Why make this change?

This is an important piece of functionality for a user authentication module. Users who forget their passwords need a way to reset them, and this form provides that capability. This form also enforces a sound practice of validating user inputs.

---

