### PR TITLE
feat(auth): add forgot password error message

### DIFF
--- a/src/app/auth/forgot-password/forgot-password-action.ts
+++ b/src/app/auth/forgot-password/forgot-password-action.ts
@@ -15,10 +15,10 @@ const forgotPasswordAction = async (
   })
 
   if (error) {
-    redirect('/forgot-password?message=Could not reset password')
+    redirect('/auth/forgot-password?message=Could not reset password')
   }
 
-  redirect('/forgot-password?message=Password reset email sent')
+  redirect('/auth/forgot-password?message=Password reset email sent')
 }
 
 export default forgotPasswordAction

--- a/src/app/auth/forgot-password/forgot-password-form.tsx
+++ b/src/app/auth/forgot-password/forgot-password-form.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useTransition } from 'react'
+import React, { FC, useTransition } from 'react'
 import {
   Form,
   FormControl,
@@ -18,7 +18,11 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import forgotPasswordAction from '@/app/auth/forgot-password/forgot-password-action'
 
-const ForgotPasswordForm = () => {
+interface Props {
+  message?: string
+}
+
+const ForgotPasswordForm: FC<Props> = ({ message }) => {
   const [isPending, startTransition] = useTransition()
   const form = useForm<z.infer<typeof ResetPasswordSchema>>({
     resolver: zodResolver(ResetPasswordSchema),
@@ -40,6 +44,9 @@ const ForgotPasswordForm = () => {
         className={'flex max-h-screen flex-col items-center justify-center'}
       >
         <AuthCard title={'Forgot Password'} subtitle={'Reset your password.'}>
+          {message && (
+            <p className={'mb-4 text-sm text-destructive'}>{message}</p>
+          )}
           <FormField
             name={'email'}
             render={({ field }) => (

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import VectorBackground from '@/app/auth/components/vector-background'
 import ForgotPasswordForm from '@/app/auth/forgot-password/forgot-password-form'
 
-const ForgotPasswordPage = () => {
+const ForgotPasswordPage = ({
+  searchParams,
+}: {
+  searchParams: { message: string }
+}) => {
   return (
     <div className={'flex flex-row justify-between'}>
       <VectorBackground
@@ -13,7 +17,7 @@ const ForgotPasswordPage = () => {
           'flex h-screen w-full flex-col items-center justify-center 2xl:w-1/3 2xl:pr-14'
         }
       >
-        <ForgotPasswordForm />
+        <ForgotPasswordForm message={searchParams.message} />
       </div>
     </div>
   )

--- a/src/app/auth/login/login-form.tsx
+++ b/src/app/auth/login/login-form.tsx
@@ -43,7 +43,9 @@ const LoginForm: FC<Props> = ({ message }) => {
         className={'flex max-h-screen flex-col items-center justify-center'}
       >
         <AuthCard title={'Login'} subtitle={'Welcome back!'}>
-          <p className={'mb-4 text-sm text-destructive'}>{message}</p>
+          {message && (
+            <p className={'mb-4 text-sm text-destructive'}>{message}</p>
+          )}
           <div className={'space-y-9'}>
             <FormField
               name={'email'}


### PR DESCRIPTION
### TL;DR

Updates related to the forgot password module and login form.

### What changed?

- Changed the redirection URL after password reset action, to include `/auth/`
- Introduced `Props` interface for `ForgotPasswordForm` and the `message` prop
- Displayed error messages on Forgot Password and Login forms with updated handling when `message` is `null`

### How to test?

- Go through the forgot password process to see the redirection updates.
- Provide incorrect details in forgot password and login forms to view the error messages.

### Why make this change?

To follow a consistent pattern in the redirection URLs in the Auth module. Also, to allow error messages, if any, to be displayed to users on the login form and the forgot password form.

---

