### PR TITLE
story: add custom view port to storyboard config

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,6 +9,7 @@ const config: StorybookConfig = {
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
     '@storybook/addon-themes',
+    '@storybook/addon-viewport',
   ],
   framework: {
     name: '@storybook/nextjs',

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,51 @@ import '@/app/globals.css'
 
 import { withThemeByClassName } from '@storybook/addon-themes'
 
+const MY_VIEWPORTS = {
+  XS: {
+    name: 'XS',
+    styles: {
+      width: '320px',
+      height: '568px',
+    },
+  },
+  SM: {
+    name: 'SM',
+    styles: {
+      width: '640px',
+      height: '1136px',
+    },
+  },
+  MD: {
+    name: 'MD',
+    styles: {
+      width: '768px',
+      height: '1024px',
+    },
+  },
+  LG: {
+    name: 'LG',
+    styles: {
+      width: '1024px',
+      height: '768px',
+    },
+  },
+  XL: {
+    name: 'XL',
+    styles: {
+      width: '1280px',
+      height: '800px',
+    },
+  },
+  XXL: {
+    name: '2XL',
+    styles: {
+      width: '1536px',
+      height: '960px',
+    },
+  },
+}
+
 const preview: Preview = {
   parameters: {
     controls: {
@@ -10,6 +55,9 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/i,
       },
+    },
+    viewport: {
+      viewports: MY_VIEWPORTS,
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@storybook/addon-links": "^8.0.9",
     "@storybook/addon-onboarding": "^8.0.9",
     "@storybook/addon-themes": "^8.0.9",
+    "@storybook/addon-viewport": "^8.0.9",
     "@storybook/blocks": "^8.0.9",
     "@storybook/nextjs": "^8.0.9",
     "@storybook/react": "^8.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@storybook/addon-themes':
         specifier: ^8.0.9
         version: 8.0.9
+      '@storybook/addon-viewport':
+        specifier: ^8.0.9
+        version: 8.0.9
       '@storybook/blocks':
         specifier: ^8.0.9
         version: 8.0.9(@types/react@18.2.8)(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)

--- a/src/app/auth/components/auth-success-card.tsx
+++ b/src/app/auth/components/auth-success-card.tsx
@@ -19,7 +19,11 @@ const AuthSuccessCard: FC<Props> = ({
   onButtonClick,
 }) => {
   return (
-    <div className={'w-full max-w-[322px] text-center'}>
+    <div
+      className={
+        'w-full max-w-[322px] text-center 2xl:bg-card 2xl:text-card-foreground'
+      }
+    >
       <Image
         src={Logo}
         alt={'MaiServe'}
@@ -34,7 +38,9 @@ const AuthSuccessCard: FC<Props> = ({
       >
         {icon}
       </span>
-      <h1 className={'mt-[29px] text-2xl font-semibold'}>{title}</h1>
+      <h1 className={'mt-[29px] text-2xl font-semibold 2xl:text-5xl'}>
+        {title}
+      </h1>
       <h3 className={'mt-0.5 text-base font-medium'}>{subtitle}</h3>
       <Button className={'mt-10 w-full'} onClick={onButtonClick}>
         {buttonTitle}


### PR DESCRIPTION
### TL;DR

Added `@storybook/addon-viewport` and defined custom viewports for different screen sizes.

### What changed?

1. Installed `@storybook/addon-viewport` and added it to the Storybook's main config file.
2. Defined custom viewports `XS`, `SM`, `MD`, `LG`, `XL`, and `2XL` in the preview file with respective dimensions.
3. Some minor styling changes in `AuthSuccessCard` component for `2XL` viewport.

### How to test?

Run Storybook and observe the ability to switch between different viewport sizes to see how components render.

### Why make this change?

This change allows developers to test and observe component behavior and responsiveness in different screen sizes right within the Storybook environment.

---

